### PR TITLE
Add explicit return types

### DIFF
--- a/src/components/base/Accordion.tsx
+++ b/src/components/base/Accordion.tsx
@@ -9,7 +9,7 @@ const Accordion = ({
   descriptions,
   descriptionTitle,
   isAcc,
-}: AccordionProps) => {
+}: AccordionProps): JSX.Element => {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedAcc, setSelectedAcc] = useState("");
 

--- a/src/components/base/FeatureCard.tsx
+++ b/src/components/base/FeatureCard.tsx
@@ -5,7 +5,7 @@ const FeatureCard = ({
   stack,
   git,
   desc,
-}: FeatureCardProps) => {
+}: FeatureCardProps): JSX.Element => {
   return (
     <div
       className={`bg-white rounded-md shadow-lg z-10 hover:scale-105 ease-in-out duration-100 ${styles}`}


### PR DESCRIPTION
## Summary
- specify `JSX.Element` return type for Accordion
- specify `JSX.Element` return type for FeatureCard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing 'react/jsx-runtime' module)*

------
https://chatgpt.com/codex/tasks/task_e_686c5a9397f8832ba554bd6f6ca094fc