### PR TITLE
Type imageStyle correctly

### DIFF
--- a/src/components/base/Card.tsx
+++ b/src/components/base/Card.tsx
@@ -6,7 +6,7 @@ const Card = ({
   projectBuiltWith,
   imageStyle,
   projectUrl,
-}: CardProp) => {
+}: CardProps) => {
   const [showDetails, setShowDetails] = useState(false);
   const [selectedJob, setSelectedJob] = useState("");
 
@@ -64,13 +64,13 @@ const Card = ({
   );
 };
 
-type CardProp = {
+export interface CardProps {
   projectName: string;
   projectDesc: string;
   projectImg: string;
   projectBuiltWith: Array<string>;
-  imageStyle?: any;
+  imageStyle?: React.CSSProperties;
   projectUrl: string;
-};
+}
 
 export default Card;

--- a/src/components/layouts/Masonry.tsx
+++ b/src/components/layouts/Masonry.tsx
@@ -1,4 +1,5 @@
 import Card from "../../components/base/Card";
+import type { CardProps } from "../../components/base/Card";
 
 import Art from "@assets/art.webp";
 import TBS from "@assets/bs.webp";
@@ -21,7 +22,7 @@ import ER from "@assets/ER.png";
 import MK from "@assets/MK.png";
 
 const Masonry = ({ ...props }) => {
-  const cards = [
+  const cards: CardProps[] = [
     {
       projectName: "Public Site (ExclusiveResorts)",
       projectDesc: "Developed a public website using Vue 3 and Nuxt 3",


### PR DESCRIPTION
## Summary
- export `CardProps` and type the optional `imageStyle` property with `React.CSSProperties`
- use `CardProps` in Masonry cards so the style object for mobile bean store card is validated

## Testing
- `npm run build` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686c5a925be0832b8c365b7a5d5ed502